### PR TITLE
add kubernetes deployment

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,9 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+  - repo: local
     hooks:
-      - id: trailing-whitespace
-      - id: end-of-file-fixer
-      - id: check-yaml
-      - id: check-json
-      - id: check-toml
-      - id: check-merge-conflict
-      - id: check-added-large-files
-      - id: debug-statements
-      - id: check-docstring-first
-
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
-    hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
-      - id: ruff-format
-
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
-    hooks:
-      - id: mypy
-        additional_dependencies: [types-requests]
-        args: [--ignore-missing-imports, --allow-untyped-decorators]
-
-  - repo: https://github.com/pycqa/bandit
-    rev: 1.7.10
-    hooks:
-      - id: bandit
-        args: ["-c", "pyproject.toml"]
-
-  - repo: https://github.com/python-poetry/poetry
-    rev: 1.8.3
-    hooks:
-      - id: poetry-check
-        files: pyproject.toml
+      - id: make-lint
+        name: make lint
+        entry: make lint
+        language: system
         pass_filenames: false
+        always_run: true

--- a/README.md
+++ b/README.md
@@ -12,11 +12,37 @@ You should have an account with Google Cloud.
 
 1. Enable Google Drive API https://console.cloud.google.com/apis/api/drive.googleapis.com
 2. Create OAuth2 application https://console.cloud.google.com/auth/clients
-3. Set Redirect URL to `https://markdown.mcp.your-domain.com/.pomerium/mcp/oauth/callback`
-4. Set Authorized Javascript Origins to `https://markdown.mcp.your-domain.com`
+3. Set Redirect URL to `https://markdown.YOUR-DOMAIN.com/.pomerium/mcp/oauth/callback`
+4. Set Authorized Javascript Origins to `https://markdown.YOUR-DOMAIN.com`
 
-# Configure Pomerium Route
+# Install To Kubernetes
 
+### Deploy this MCP server
+
+Install with Kustomize:
+```shell
+kubectl apply -k github.com/pomerium/mcp-markdown/k8s
+```
+
+check your deployment:
+```shell
+kubectl rollout status deployment/mcp-markdown -n pomerium-mcp-markdown
+```
+
+### Front it with Pomerium Ingress Controller
+
+[Install and configure](https://main.docs.pomerium.com/docs/deploy/k8s/install) Pomerium Ingress controller that would front your HTTP MCP Servers.
+
+Pomerium uses a dedicated `pomerium` `IngressClass` and does not interfere with your existing controllers.
+
+### Deploy Ingress and Secret
+
+Create [`Ingress`](./k8s/ingress-example.yaml) and [OAuth2 `Secret`](./k8s/secret-example.yaml) using examples provided and deploy them to your cluster in the `pomerium-mcp-markdown` namespace.
+
+# Install on a VM or Docker Compose
+
+```yaml
+routes:
   - from: https://markdown.mcp.your-domain.com
     to: http://localhost:8000
     name: Markdown
@@ -36,3 +62,4 @@ You should have an account with Google Cloud.
             auth_url:  "https://accounts.google.com/o/oauth2/v2/auth"
             token_url: "https://oauth2.googleapis.com/token"
     timeout: 120s
+```

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-markdown
+  labels:
+    app: mcp-markdown
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-markdown
+  template:
+    metadata:
+      labels:
+        app: mcp-markdown
+    spec:
+      containers:
+      - name: mcp-markdown
+        image: pomerium/mcp-markdown:main
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8000
+          name: http
+        env:
+        - name: PORT
+          value: "8000"
+        - name: HOST
+          value: "0.0.0.0"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 30
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL

--- a/k8s/ingress-example.yaml
+++ b/k8s/ingress-example.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mcp-markdown
+  labels:
+    name: mcp-markdown
+  annotations:
+    ingress.pomerium.io/name: 'Markdown'
+    ingress.pomerium.io/mcp_server_path: '/mcp/'
+    ingress.pomerium.io/mcp_server_upstream_oauth2_secret: 'gdrive-oauth2-secret'
+    ingress.pomerium.io/mcp_server_upstream_oauth2_auth_url: "https://accounts.google.com/o/oauth2/v2/auth"
+    ingress.pomerium.io/mcp_server_upstream_oauth2_token_url: "https://oauth2.googleapis.com/token"
+    ingress.pomerium.io/mcp_server_upstream_oauth2_scopes: 'https://www.googleapis.com/auth/drive.readonly'
+    ingress.pomerium.io/timeout: '2m'
+    ingress.pomerium.io/policy: |
+      allow:
+        and:
+          - domain:
+              is: YOUR-DOMAIN.com
+    # *** Replace YOUR-DOMAIN.com with your actual domain ***
+spec:
+  ingressClassName: pomerium
+  rules:
+    # *** Replace YOUR-DOMAIN.com with your actual domain ***
+  - host: mcp-markdown.YOUR-DOMAIN.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: mcp-markdown
+            port:
+              name: http

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: pomerium-mcp-markdown
+
+resources:
+- namespace.yaml
+- deployment.yaml
+- service.yaml
+
+commonLabels:
+  app: mcp-markdown
+  version: v1.0.0

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pomerium-mcp-markdown
+  labels:
+    name: pomerium-mcp-markdown

--- a/k8s/secret-example.yaml
+++ b/k8s/secret-example.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: 'gdrive-oauth2-secret'
+type: Opaque
+stringData:
+  client_id: ''
+  client_secret: ''

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-markdown
+  labels:
+    app: mcp-markdown
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 8000
+    protocol: TCP
+    name: http
+  selector:
+    app: mcp-markdown

--- a/server.py
+++ b/server.py
@@ -343,7 +343,7 @@ mcp: FastMCP = FastMCP(
 )
 
 
-@mcp.custom_route("/health", methods=["GET"])
+@mcp.custom_route("/health", methods=["GET"])  # type: ignore[misc]
 async def health_check(request: Request) -> JSONResponse:
     """Health check endpoint for monitoring and load balancing"""
     return JSONResponse({"status": "healthy", "service": "mcp-markdown-server"})

--- a/server.py
+++ b/server.py
@@ -10,12 +10,14 @@ import os
 import re
 import sys
 import threading
-from typing import Literal
 
 import anyio
 import structlog
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
 
 # Configure structlog for clean console output
 structlog.configure(
@@ -307,7 +309,44 @@ def extract_bearer_token(ctx: Context) -> str | None:
         return None
 
 
-mcp: FastMCP = FastMCP("mcp-markdown-server")
+class MCPPathRewriteMiddleware:
+    """
+    Middleware to rewrite /mcp requests to /mcp/ to avoid 307 redirects.
+
+    This fixes the issue where FastMCP's Mount routing expects a trailing slash
+    but clients might send requests without it, causing Starlette to return
+    307 Temporary Redirect responses.
+    """
+
+    def __init__(self, app: ASGIApp, mcp_path: str = "/mcp"):
+        self.app = app
+        self.mcp_path = mcp_path
+        self.mcp_path_with_slash = mcp_path + "/"
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "http":
+            path = scope["path"]
+
+            if path == self.mcp_path:
+                scope["path"] = self.mcp_path_with_slash
+                logger.debug(
+                    f"Rewriting path from {self.mcp_path} to {self.mcp_path_with_slash}"
+                )
+
+        await self.app(scope, receive, send)
+
+
+mcp: FastMCP = FastMCP(
+    "mcp-markdown-server",
+    streamable_http_path="/mcp",
+    stateless_http=True,
+)
+
+
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
+    """Health check endpoint for monitoring and load balancing"""
+    return JSONResponse({"status": "healthy", "service": "mcp-markdown-server"})
 
 
 @mcp.tool()
@@ -389,41 +428,31 @@ if __name__ == "__main__":
     host = os.getenv("HOST", "localhost")
     port = int(os.getenv("PORT", 8000))
     log_level = os.getenv("LOG_LEVEL", "INFO")
-    transport = os.getenv("TRANSPORT", "http")
-
-    # Cast transport to the correct literal type
-    valid_transports: set[str] = {"stdio", "http", "sse", "streamable-http"}
-    if transport not in valid_transports:
-        logger.error(
-            f"Invalid transport: {transport}. Must be one of {valid_transports}"
-        )
-        sys.exit(1)
-
-    transport_typed: Literal["stdio", "http", "sse", "streamable-http"] = transport  # type: ignore
 
     logger.info(
         "Starting FastMCP Markdown server",
         host=host,
         port=port,
         log_level=log_level,
-        transport=transport,
+        transport="streamable-http",
     )
-    logger.info("Authentication: Bearer token extracted from Authorization header")
 
     logger.info("Server provides the following tools")
     logger.info(
         "Tool available: convert_to_markdown - Convert Google Drive URLs to markdown"
     )
+    logger.info(f"Endpoint: http://{host}:{port}/mcp")
+    logger.info("Authentication: Bearer token in Authorization header")
 
-    if transport == "http":
-        logger.info("Server configuration", transport=transport, host=host, port=port)
-        logger.info(f"Endpoint: http://{host}:{port}/mcp")
-        logger.info("Authentication: Bearer token in Authorization header")
+    from starlette.middleware import Middleware
+
+    middleware = [Middleware(MCPPathRewriteMiddleware, mcp_path="/mcp")]
 
     mcp.run(
-        transport=transport_typed,
+        transport="streamable-http",
         host=host,
         port=port,
         log_level=log_level.lower(),
         stateless_http=True,
+        middleware=middleware,
     )


### PR DESCRIPTION
## Description

- Adds Kubernetes deployment and instructions. 
- Also fixes `/mcp` route to not return redirect to `/mcp/` which seems to be a default behaviour but is not understood by most MCP clients. 
- Adds a liveness / readiness check handler. 
